### PR TITLE
add support for arrays in next

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "immer": "^9.0.12",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.3",
+    "ts-toolbelt": "^9.6.0",
     "typescript": "^4.5.4",
     "zustand": "^4.0.0-rc.1"
   },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -59,6 +59,72 @@ describe("createLens", () => {
     expect(store.getState().getter()).toEqual({ id: 456, prop: "qwe-qwe" });
   });
 
+  it("works with arrays", () => {
+    type State = {
+      deeply: {
+        nested: {
+          array: {
+            id: number;
+            prop: string;
+          }[];
+        };
+      };
+
+      getter;
+      partial;
+      partialFn;
+      replace;
+      replaceFn;
+    };
+
+    const store = create<State>((set, get) => {
+      const [_set, _get] = createLens(set, get, [
+        "deeply",
+        "nested",
+        "array",
+        0,
+      ]);
+
+      return {
+        deeply: {
+          nested: {
+            array: [
+              {
+                id: 123,
+                prop: "abc",
+              },
+            ],
+          },
+        },
+
+        getter: _get,
+
+        partial: () => _set({ prop: "def" }),
+
+        partialFn: () => _set((old) => ({ prop: old!.prop + "-def" })),
+
+        replace: () => _set({ prop: "qwe" }, true),
+
+        replaceFn: () =>
+          _set((old) => ({ id: 456, prop: old!.prop + "-qwe" }), true),
+      };
+    });
+
+    expect(store.getState().getter()).toEqual({ id: 123, prop: "abc" });
+
+    store.getState().partial();
+    expect(store.getState().getter()).toEqual({ id: 123, prop: "def" });
+
+    store.getState().partialFn();
+    expect(store.getState().getter()).toEqual({ id: 123, prop: "def-def" });
+
+    store.getState().replace();
+    expect(store.getState().getter()).toEqual({ prop: "qwe" });
+
+    store.getState().replaceFn();
+    expect(store.getState().getter()).toEqual({ id: 456, prop: "qwe-qwe" });
+  });
+
   it("takes `path` as `string | string[]`", () => {
     let store = {
       subA: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,6 +2412,11 @@ ts-jest@^27.1.3:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-toolbelt@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz#50a25426cfed500d4a09bd1b3afb6f28879edfd5"
+  integrity sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"


### PR DESCRIPTION
Also solving #9. This was a bit more complicated cause the `Path` type didn't resolve arrays correctly. I added `ts-toolbelt` as an alternative. However ts-toolbelt returns `type | undefined` for array values. 